### PR TITLE
Update to recent RxJava

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,4 +40,4 @@ task(rspec, type: JavaExec) {
     args 'classpath:bin/rspec', 'src/spec/ruby'
 }
 
-tasks.build.dependsOn << 'rspec'
+tasks.check.dependsOn << 'rspec'

--- a/build.gradle
+++ b/build.gradle
@@ -5,6 +5,10 @@ buildscript {
 
 apply plugin: 'rxjava-project'
 
+configurations {
+    rspec
+}
+
 dependencies {
     compile 'io.reactivex:rxjava:1.0.+'
     compile 'org.jruby:jruby:1.7+'
@@ -22,10 +26,6 @@ repositories {
     mavenCentral()
 }
 
-configurations {
-    rspec
-}
-
 sourceSets {
     test {
         resources {
@@ -33,3 +33,13 @@ sourceSets {
         }
     }
 }
+
+/*
+task(rspec, type: JavaExec) {
+    main 'org.jruby.Main'
+    classpath configurations.rspec + runtimeClasspath
+    args 'classpath:bin/rspec', 'src/spec/ruby'
+}
+
+tasks.build.dependsOn << 'rspec'
+*/

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,6 @@ sourceSets {
     }
 }
 
-/*
 task(rspec, type: JavaExec) {
     main 'org.jruby.Main'
     classpath configurations.rspec + runtimeClasspath
@@ -42,4 +41,3 @@ task(rspec, type: JavaExec) {
 }
 
 tasks.build.dependsOn << 'rspec'
-*/

--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ sourceSets {
     }
 }
 
-task(rspec, type: JavaExec) {
+task(rspec, type: JavaExec, dependsOn: 'classes') {
     main 'org.jruby.Main'
     classpath configurations.rspec + runtimeClasspath
     args 'classpath:bin/rspec', 'src/spec/ruby'

--- a/src/main/resources/rx/lang/jruby/interop.rb
+++ b/src/main/resources/rx/lang/jruby/interop.rb
@@ -16,15 +16,15 @@ module Rx
   module Lang
     module Jruby
       class Interop
-        WRAPPERS = {
-          Java::RxUtilFunctions::Action         => Java::RxLangJruby::JRubyActionWrapper,
-          Java::Rx::Observable::OnSubscribeFunc => false
-        }
+        WRAPPERS = [
+          [Java::Rx::Observable::OnSubscribe, false],
+          [Java::RxFunctions::Action, Java::RxLangJruby::JRubyActionWrapper]
+        ]
 
-        WRAPPERS.default = Java::RxLangJruby::JRubyFunctionWrapper
+        DEFAULT_WRAPPER = Java::RxLangJruby::JRubyFunctionWrapper
 
         KLASSES  = [Java::Rx::Observable, Java::RxObservables::BlockingObservable]
-        FUNCTION = Java::RxUtilFunctions::Function.java_class
+        FUNCTION = Java::RxFunctions::Function.java_class
         RUNTIME  = JRuby.runtime
 
         def self.instance
@@ -48,10 +48,10 @@ module Rx
                   type.ruby_class.ancestors.include?(java_class)
                 end
 
-                # Skip OnSubscribeFuncs
+                # Skip OnSubscribes
                 next if constructor && constructor.last == false
 
-                constructor = (constructor && constructor.last) || WRAPPERS.default
+                constructor = (constructor && constructor.last) || DEFAULT_WRAPPER
 
                 parameter_types[[method.name, method.static?]][idx] ||= []
                 parameter_types[[method.name, method.static?]][idx] << constructor

--- a/src/spec/ruby/rx/lang/jruby/interop_spec.rb
+++ b/src/spec/ruby/rx/lang/jruby/interop_spec.rb
@@ -21,8 +21,8 @@ describe Rx::Lang::Jruby::Interop do
 
   context "with a normal, non-function method signature" do
     it "calls straight through to the original Java method" do
-      observable.should_not_receive(:toBlockingObservable_without_wrapping)
-      observable.toBlockingObservable.should be_a(Java::RxObservables::BlockingObservable)
+      observable.should_not_receive(:toBlocking_without_wrapping)
+      observable.toBlocking.should be_a(Java::RxObservables::BlockingObservable)
     end
   end
 
@@ -43,7 +43,7 @@ describe Rx::Lang::Jruby::Interop do
       observable.subscribe(1)
     end
 
-    it "doesn't wrap OnSubscribeFunc arguments" do
+    it "doesn't wrap OnSubscribe arguments" do
       proc = lambda {|observer| observer.onNext("hi")}
       Java::Rx::Observable.__persistent__ = true
       Java::Rx::Observable.should_not_receive(:create_without_wrapping)

--- a/src/spec/ruby/rx/lang/jruby/jruby_action_wrapper_spec.rb
+++ b/src/spec/ruby/rx/lang/jruby/jruby_action_wrapper_spec.rb
@@ -19,11 +19,11 @@ describe Java::RxLangJruby::JRubyActionWrapper do
   subject { described_class.new(JRuby.runtime.get_current_context, lambda {|*args| spy.call(args)}) }
 
   let(:interfaces) do
-    [Java::RxUtilFunctions::Action,
-     Java::RxUtilFunctions::Action0,
-     Java::RxUtilFunctions::Action1,
-     Java::RxUtilFunctions::Action2,
-     Java::RxUtilFunctions::Action3]
+    [Java::RxFunctions::Action,
+     Java::RxFunctions::Action0,
+     Java::RxFunctions::Action1,
+     Java::RxFunctions::Action2,
+     Java::RxFunctions::Action3]
   end
 
   it "implements the interfaces" do

--- a/src/spec/ruby/rx/lang/jruby/jruby_function_wrapper_spec.rb
+++ b/src/spec/ruby/rx/lang/jruby/jruby_function_wrapper_spec.rb
@@ -19,17 +19,17 @@ describe Java::RxLangJruby::JRubyFunctionWrapper do
   subject { described_class.new(JRuby.runtime.get_current_context, lambda {|*args| spy.call(args); args}) }
 
   let(:interfaces) do
-    [Java::RxUtilFunctions::Func0,
-     Java::RxUtilFunctions::Func1,
-     Java::RxUtilFunctions::Func2,
-     Java::RxUtilFunctions::Func3,
-     Java::RxUtilFunctions::Func4,
-     Java::RxUtilFunctions::Func5,
-     Java::RxUtilFunctions::Func6,
-     Java::RxUtilFunctions::Func7,
-     Java::RxUtilFunctions::Func8,
-     Java::RxUtilFunctions::Func9,
-     Java::RxUtilFunctions::FuncN]
+    [Java::RxFunctions::Func0,
+     Java::RxFunctions::Func1,
+     Java::RxFunctions::Func2,
+     Java::RxFunctions::Func3,
+     Java::RxFunctions::Func4,
+     Java::RxFunctions::Func5,
+     Java::RxFunctions::Func6,
+     Java::RxFunctions::Func7,
+     Java::RxFunctions::Func8,
+     Java::RxFunctions::Func9,
+     Java::RxFunctions::FuncN]
   end
 
   it "implements the interfaces" do


### PR DESCRIPTION
In recent RxJava some interfaces has been renamed, and also `Java::Rx::Observable::OnSubscribe` now also inherits from `Java::RxFunctions::Action` so wrappers collection turned to array to check them in predictable order (ruby 1.8 does not guarantee ordered hashes)
